### PR TITLE
Removed dependency on slf4j-simple and Fixed javadoc warnings.

### DIFF
--- a/stl-decomp-4j/pom.xml
+++ b/stl-decomp-4j/pom.xml
@@ -55,11 +55,6 @@
       <artifactId>commons-math3</artifactId>
       <version>[3.6,]</version>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.6.1</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/CyclicSubSeriesSmoother.java
+++ b/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/CyclicSubSeriesSmoother.java
@@ -2,7 +2,7 @@ package com.github.servicenow.ds.stats.stl;
 
 /**
  * Encapsulate the complexity of smoothing the cyclic sub-series in a separate class.
- *
+ * <p>
  * Created by Jim Crotinger on 13-May-2016.
  */
 @SuppressWarnings("WeakerAccess")
@@ -37,7 +37,7 @@ public class CyclicSubSeriesSmoother {
 		/**
 		 * Set the width of the LOESS smoother used to smooth each seasonal sub-series.
 		 *
-		 * @param width
+		 * @param width width of the LOESS smoother
 		 * @return this
 		 */
 		public Builder setWidth(int width) {
@@ -48,7 +48,7 @@ public class CyclicSubSeriesSmoother {
 		/**
 		 * Set the degree of the LOESS smoother used to smooth each seasonal sub-series.
 		 *
-		 * @param degree
+		 * @param degree degree of the LOESS smoother
 		 * @return this
 		 */
 		public Builder setDegree(int degree) {
@@ -61,10 +61,10 @@ public class CyclicSubSeriesSmoother {
 
 		/**
 		 * Set the jump (number of points to skip) between LOESS interpolations when smoothing the seasonal sub-series.
-		 *
+		 * <p>
 		 * Defaults to 1 (computes LOESS interpolation at each point).
 		 *
-		 * @param jump
+		 * @param jump jump (number of points to skip) in the LOESS smoother
 		 * @return this
 		 */
 		public Builder setJump(int jump) {
@@ -75,7 +75,7 @@ public class CyclicSubSeriesSmoother {
 		/**
 		 * Set the total length of the data that will be deconstructed into cyclic sub-series.
 		 *
-		 * @param dataLength
+		 * @param dataLength total length of the data
 		 * @return this
 		 */
 		public Builder setDataLength(int dataLength) {
@@ -86,7 +86,7 @@ public class CyclicSubSeriesSmoother {
 		/**
 		 * Set the period of the data's seasonality.
 		 *
-		 * @param periodicity
+		 * @param periodicity number of data points in each season or period
 		 * @return this
 		 */
 		public Builder setPeriodicity(int periodicity) {
@@ -97,7 +97,7 @@ public class CyclicSubSeriesSmoother {
 		/**
 		 * Construct a smoother that will extrapolate forward only by the specified number of periods.
 		 *
-		 * @param periods
+		 * @param periods number of periods to extrapolate
 		 * @return this
 		 */
 		public Builder extrapolateForwardOnly(int periods) {
@@ -108,9 +108,9 @@ public class CyclicSubSeriesSmoother {
 
 		/**
 		 * Construct a smoother that extrapolates forward and backward by the specified number of periods.
-
-		 * @param periods
-		 * @return
+		 *
+		 * @param periods number of periods to extrapolate
+		 * @return this
 		 */
 		public Builder extrapolateForwardAndBack(int periods) {
 			fNumPeriodsForward = periods;
@@ -120,10 +120,10 @@ public class CyclicSubSeriesSmoother {
 
 		/**
 		 * Set the number of periods to extrapolate forward.
-		 *
+		 * <p>
 		 * Defaults to 1.
 		 *
-		 * @param periods
+		 * @param periods number of periods to extrapolate
 		 * @return this
 		 */
 		public Builder setNumPeriodsForward(int periods) {
@@ -133,10 +133,10 @@ public class CyclicSubSeriesSmoother {
 
 		/**
 		 * Set the number of periods to extrapolate backward.
-		 *
+		 * <p>
 		 * Defaults to 1.
 		 *
-		 * @param periods
+		 * @param periods number of periods to extrapolate
 		 * @return this
 		 */
 		public Builder setNumPeriodsBackward(int periods) {
@@ -178,24 +178,17 @@ public class CyclicSubSeriesSmoother {
 	/**
 	 * Create a cyclic sub-series smoother with the specified properties.
 	 *
-	 * @param width
-	 *      - width of the LOESS smoother
-	 * @param degree
-	 *      - degree of the LOESS smoother
-	 * @param jump
-	 *      - jump to use in LOESS smoothing
-	 * @param dataLength
-	 *      - length of the input data
-	 * @param periodicity
-	 *      - length of the cyclic period
-	 * @param numPeriodsToExtrapolateBackward
-	 *      - number of periods to extrapolate backward
-	 * @param numPeriodsToExtrapolateForward
-	 *      - numbers of periods to extrapolate forward
+	 * @param width                           width of the LOESS smoother
+	 * @param degree                          degree of the LOESS smoother
+	 * @param jump                            jump to use in LOESS smoothing
+	 * @param dataLength                      length of the input data
+	 * @param periodicity                     length of the cyclic period
+	 * @param numPeriodsToExtrapolateBackward number of periods to extrapolate backward
+	 * @param numPeriodsToExtrapolateForward  numbers of periods to extrapolate forward
 	 */
 	CyclicSubSeriesSmoother(int width, int degree, int jump,
-							int dataLength, int periodicity,
-                            int numPeriodsToExtrapolateBackward, int numPeriodsToExtrapolateForward) {
+	                        int dataLength, int periodicity,
+	                        int numPeriodsToExtrapolateBackward, int numPeriodsToExtrapolateForward) {
 		fWidth = width;
 
 		fLoessSmootherFactory = new LoessSmoother.Builder().setWidth(width).setJump(jump).setDegree(degree);
@@ -235,12 +228,9 @@ public class CyclicSubSeriesSmoother {
 	 * Run the cyclic sub-series smoother on the specified data, with the specified weights (ignored if null). The
 	 * sub-series are reconstructed into a single series in smoothedData.
 	 *
-	 * @param rawData
-	 *            double[] input data
-	 * @param smoothedData
-	 *            double[] output data
-	 * @param weights
-	 *            double[] weights to use in the underlying interpolator; ignored if null.
+	 * @param rawData      input data
+	 * @param smoothedData output data
+	 * @param weights      weights to use in the underlying interpolator; ignored if null.
 	 */
 	public void smoothSeasonal(double[] rawData, double[] smoothedData, double[] weights) {
 		extractRawSubSeriesAndWeights(rawData, weights);
@@ -287,11 +277,11 @@ public class CyclicSubSeriesSmoother {
 	 * Use LOESS interpolation on each of the cyclic sub-series (e.g. in monthly data, smooth the Januaries, Februaries,
 	 * etc.).
 	 *
-	 * @param weights
-	 * @param rawData
-	 * @param smoothedData
+	 * @param weights      external weights for interpolation
+	 * @param rawData      input data to be smoothed
+	 * @param smoothedData output smoothed data
 	 */
-	 private void smoothOneSubSeries(double[] weights, double[] rawData, double[] smoothedData) {
+	private void smoothOneSubSeries(double[] weights, double[] rawData, double[] smoothedData) {
 
 		final int cycleLength = rawData.length;
 

--- a/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/LoessSmoother.java
+++ b/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/LoessSmoother.java
@@ -4,7 +4,7 @@ package com.github.servicenow.ds.stats.stl;
  * LoessSmoother uses LOESS interpolation to compute a smoothed data set from a regularly-spaced set of input
  * data. If a jump is specified, then LOESS interpolation is only done on every jump points and linear interpolation is
  * done to fill in the gaps.
- *
+ * <p>
  * Author: Jim Crotinger, ported from the original RATFOR source from netlib
  */
 @SuppressWarnings("WeakerAccess")
@@ -26,7 +26,7 @@ public class LoessSmoother {
 		/**
 		 * Set the width of the LOESS smoother.
 		 *
-		 * @param width
+		 * @param width width of the LOESS smoother
 		 * @return this
 		 */
 		public Builder setWidth(int width) {
@@ -36,10 +36,10 @@ public class LoessSmoother {
 
 		/**
 		 * Set the degree of the LOESS smoother.
-		 *
+		 * <p>
 		 * Defaults to 1.
 		 *
-		 * @param degree
+		 * @param degree degree of the LOESS smoother
 		 * @return this
 		 */
 		public Builder setDegree(int degree) {
@@ -52,10 +52,10 @@ public class LoessSmoother {
 
 		/**
 		 * Set the jump (number of points to skip) between LOESS interpolations.
-		 *
+		 * <p>
 		 * Defaults to 1 (computes LOESS interpolation at each point).
 		 *
-		 * @param jump
+		 * @param jump number of points to skip
 		 * @return this
 		 */
 		public Builder setJump(int jump) {
@@ -65,10 +65,10 @@ public class LoessSmoother {
 
 		/**
 		 * Set the external weights for interpolation.
-		 *
+		 * <p>
 		 * Not required - null is equivalent to all weights being 1.
 		 *
-		 * @param weights
+		 * @param weights external weights for interpolation
 		 * @return this
 		 */
 		public Builder setExternalWeights(double[] weights) {
@@ -78,10 +78,10 @@ public class LoessSmoother {
 
 		/**
 		 * Set the data to be smoothed.
-		 *
+		 * <p>
 		 * Note that smoothing does not modify this data.
 		 *
-		 * @param data
+		 * @param data input data to be smoothed
 		 * @return this
 		 */
 		public Builder setData(double[] data) {
@@ -113,16 +113,11 @@ public class LoessSmoother {
 	 * Create a LoessSmoother for the given data set with the specified smoothing width and optional external
 	 * Weights.
 	 *
-	 * @param width
-	 *            int approximate width the width of the neighborhood weighting function
-	 * @param jump
-	 *            int smoothing jump - only ever jump points are smoothed by LOESS with linear interpolation in between.
-	 * @param degree
-	 *            int 1 for linear regression, 0 for simple weighted average
-	 * @param data
-	 *            double[] underlying data set that is being smoothed
-	 * @param externalWeights
-	 *            double[] additional weights to apply in the smoothing. Ignored if null.
+	 * @param width           approximate width the width of the neighborhood weighting function
+	 * @param jump            smoothing jump - only ever jump points are smoothed by LOESS with linear interpolation in between.
+	 * @param degree          1 for linear regression, 0 for simple weighted average
+	 * @param data            underlying data set that is being smoothed
+	 * @param externalWeights additional weights to apply in the smoothing. Ignored if null.
 	 */
 	private LoessSmoother(int width, int jump, int degree, double[] data, double[] externalWeights) {
 		final LoessInterpolator.Builder b = new LoessInterpolator.Builder();

--- a/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/SeasonalTrendLoess.java
+++ b/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/SeasonalTrendLoess.java
@@ -7,7 +7,7 @@ import static com.github.servicenow.ds.stats.TimeSeriesUtilities.simpleMovingAve
 /**
  * Java implementation of the Seasonal-Trend-Loess algorithm for evenly spaced data. This is basically a direct port of
  * the RATFOR from the netlib stl package.
- *
+ * <p>
  * Created by Jim Crotinger on 18-Apr-2016.
  */
 public class SeasonalTrendLoess {
@@ -71,10 +71,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the period length for the STL seasonal decomposition.
-		 *
+		 * <p>
 		 * Required - no default.
 		 *
-		 * @param period
+		 * @param period period length (number of data points in each season or period)
 		 * @return this
 		 */
 		public Builder setPeriodLength(int period) {
@@ -87,10 +87,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the LOESS width (in data points) used to smooth the seasonal sub-series.
-		 *
+		 * <p>
 		 * Required unless setPeriodic is called.
 		 *
-		 * @param width
+		 * @param width LOESS width for the seasonal sub-series
 		 * @return this
 		 */
 		public Builder setSeasonalWidth(int width) {
@@ -100,10 +100,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the LOESS degree used to smooth the seasonal sub-series.
-		 *
+		 * <p>
 		 * Defaults to 1.
 		 *
-		 * @param degree
+		 * @param degree LOESS degree for the seasonal sub-series
 		 * @return this
 		 */
 		public Builder setSeasonalDegree(int degree) {
@@ -113,10 +113,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the jump (number of points to skip) between LOESS interpolations when smoothing the seasonal sub-series.
-		 *
+		 * <p>
 		 * Defaults to 10% of the smoother width.
 		 *
-		 * @param jump
+		 * @param jump LOESS jump (number of points to skip) for the seasonal sub-series
 		 * @return this
 		 */
 		public Builder setSeasonalJump(int jump) {
@@ -126,10 +126,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the LOESS width (in data points) used to smooth the trend.
-		 *
+		 * <p>
 		 * Defaults to (int) (1.5 * periodLength / (1 - 1.5 / seasonalWidth) + 0.5)
 		 *
-		 * @param width
+		 * @param width LOESS with for the trend component
 		 * @return this
 		 */
 		public Builder setTrendWidth(int width) {
@@ -139,10 +139,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the LOESS degree used to smooth the trend.
-		 *
+		 * <p>
 		 * Defaults to 1.
 		 *
-		 * @param degree
+		 * @param degree LOESS degree for the trend component
 		 * @return this
 		 */
 		public Builder setTrendDegree(int degree) {
@@ -152,10 +152,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the jump (number of points to skip) between LOESS interpolations used when smoothing the trend.
-		 *
+		 * <p>
 		 * Defaults to 10% of the smoother width.
 		 *
-		 * @param jump
+		 * @param jump LOESS jump (number of points to skip) for the trend component
 		 * @return this
 		 */
 		public Builder setTrendJump(int jump) {
@@ -165,10 +165,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the LOESS width (in data points) used by the low-pass filter step.
-		 *
+		 * <p>
 		 * Defaults to the period length.
 		 *
-		 * @param width
+		 * @param width LOESS width for the low-pass step
 		 * @return this
 		 */
 		public Builder setLowpassWidth(int width) {
@@ -178,10 +178,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the LOESS degree used by the low-pass filter step.
-		 *
+		 * <p>
 		 * Defaults to 1.
 		 *
-		 * @param degree
+		 * @param degree LOESS degree for the low-pass step
 		 * @return this
 		 */
 		public Builder setLowpassDegree(int degree) {
@@ -191,10 +191,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the jump (number of points to skip) between LOESS interpolations used by the low-pass filter step.
-		 *
+		 * <p>
 		 * Defaults to 10% of the smoother width.
 		 *
-		 * @param jump
+		 * @param jump LOESS jump (number of points to skip) for the low-pass step
 		 * @return this
 		 */
 		public Builder setLowpassJump(int jump) {
@@ -204,10 +204,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the number of STL inner iterations.
-		 *
+		 * <p>
 		 * Required, but also set by setRobust, setNonRobust, setRobustFlag.
 		 *
-		 * @param ni
+		 * @param ni number of inner iterations
 		 * @return this
 		 */
 		public Builder setInnerIterations(int ni) {
@@ -217,10 +217,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Set the number of STL robustness (outer) iterations.
-		 *
+		 * <p>
 		 * Required, but also set by setRobust, setNonRobust, setRobustFlag.
 		 *
-		 * @param no
+		 * @param no number of outer iterations
 		 * @return this
 		 */
 		public Builder setRobustnessIterations(int no) {
@@ -253,7 +253,7 @@ public class SeasonalTrendLoess {
 		/**
 		 * Set the robustness according to a flag; e.g. setRobust if true, setNonRobust if false.
 		 *
-		 * @param robust
+		 * @param robust true to be robust
 		 * @return this
 		 */
 		public Builder setRobustFlag(boolean robust) {
@@ -389,18 +389,18 @@ public class SeasonalTrendLoess {
 	/**
 	 * Construct STL specifying full details of the LOESS smoothers via LoessSettings objects.
 	 *
-	 * @param data             - the data to be decomposed
-	 * @param periodicity      - the periodicity of the data
-	 * @param ni               - the number of inner iterations
-	 * @param no               - the number of outer "robustness" iterations
-	 * @param seasonalSettings - the settings for the LOESS smoother for the cyclic sub-series
-	 * @param trendSettings    - the settings for the LOESS smoother for the trend component
-	 * @param lowpassSettings  - the settings for the LOESS smoother used in de-seasonalizing
+	 * @param data             the data to be decomposed
+	 * @param periodicity      the periodicity of the data
+	 * @param ni               the number of inner iterations
+	 * @param no               the number of outer "robustness" iterations
+	 * @param seasonalSettings the settings for the LOESS smoother for the cyclic sub-series
+	 * @param trendSettings    the settings for the LOESS smoother for the trend component
+	 * @param lowpassSettings  the settings for the LOESS smoother used in de-seasonalizing
 	 */
 	// Could be private but causes a hidden class to be generated in order for the Builder to have access.
 	@SuppressWarnings("WeakerAccess")
 	SeasonalTrendLoess(double[] data, int periodicity, int ni, int no, LoessSettings seasonalSettings,
-                       LoessSettings trendSettings, LoessSettings lowpassSettings) {
+	                   LoessSettings trendSettings, LoessSettings lowpassSettings) {
 
 		fData = data;
 
@@ -437,7 +437,7 @@ public class SeasonalTrendLoess {
 
 	/**
 	 * Factory method to perform a non-robust STL decomposition enforcing strict periodicity.
-	 *
+	 * <p>
 	 * Meant for diagnostic purposes only.
 	 *
 	 * @param data        the data to analyze
@@ -468,7 +468,7 @@ public class SeasonalTrendLoess {
 
 	/**
 	 * Factory method to perform a (somewhat) robust STL decomposition enforcing strict periodicity.
-	 *
+	 * <p>
 	 * Meant for diagnostic purposes only.
 	 *
 	 * @param data        the data to analyze
@@ -510,10 +510,10 @@ public class SeasonalTrendLoess {
 
 		/**
 		 * Initialize Decomposition object from the original data.
-		 *
+		 * <p>
 		 * Allocates space for the decomposition and initializes the weights to 1.
 		 *
-		 * @param data
+		 * @param data input data
 		 */
 		Decomposition(double[] data) {
 			fData = data;
@@ -599,7 +599,7 @@ public class SeasonalTrendLoess {
 			// superfluous work when the number is odd.
 
 			final int mi0 = (fData.length + 1) / 2 - 1; // n = 5, mi0 = 2; n = 4, mi0 = 1
-			final int mi1 = fData.length - mi0 - 1;		// n = 5, mi1 = 2; n = 4, mi1 = 2
+			final int mi1 = fData.length - mi0 - 1;        // n = 5, mi1 = 2; n = 4, mi1 = 2
 
 			final double sixMad = 3.0 * (fWeights[mi0] + fWeights[mi1]);
 			final double c999 = 0.999 * sixMad;
@@ -622,8 +622,7 @@ public class SeasonalTrendLoess {
 		/**
 		 * Smooth the STL seasonal component with quadratic LOESS and recompute the residual.
 		 *
-		 * @param width
-		 *            the width of the LOESS smoother used to smooth the seasonal component.
+		 * @param width the width of the LOESS smoother used to smooth the seasonal component.
 		 */
 		public void smoothSeasonal(int width) {
 			// Quadratic smoothing of the seasonal component.
@@ -725,15 +724,15 @@ public class SeasonalTrendLoess {
 		//
 		// and the length after each pass is.................................
 		double[] pass1 = simpleMovingAverage(fExtendedSeasonal, fPeriodLength); // data.length + periodLength + 1
-		double[] pass2 = simpleMovingAverage(pass1, fPeriodLength);				// data.length + 2
-		double[] pass3 = simpleMovingAverage(pass2, 3);							// data.length
+		double[] pass2 = simpleMovingAverage(pass1, fPeriodLength);                // data.length + 2
+		double[] pass3 = simpleMovingAverage(pass2, 3);                            // data.length
 
 		// assert pass3.length == fData.length; // testing sanity check.
 
 		LoessSmoother lowPassLoess = fLowpassLoessFactory.setData(pass3).build();
 		fDeSeasonalized = lowPassLoess.smooth();
 
-	    // dumpDebugData("lowpass", fDeSeasonalized);
+		// dumpDebugData("lowpass", fDeSeasonalized);
 	}
 
 	/**
@@ -768,12 +767,12 @@ public class SeasonalTrendLoess {
 	public String toString() {
 		return String.format(
 				"SeasonalTrendLoess: [\n" +
-				"inner iterations     = %d\n" +
-				"outer iterations     = %d\n" +
-				"periodicity          = %d\n" +
-				"seasonality settings = %s\n" +
-				"trend settings       = %s\n" +
-				"lowpass settings     = %s\n]",
+						"inner iterations     = %d\n" +
+						"outer iterations     = %d\n" +
+						"periodicity          = %d\n" +
+						"seasonality settings = %s\n" +
+						"trend settings       = %s\n" +
+						"lowpass settings     = %s\n]",
 				this.fInnerIterations, this.fRobustIterations, this.fPeriodLength,
 				this.fSeasonalSettings, this.fTrendSettings, this.fLowpassSettings);
 	}

--- a/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/StlFitStats.java
+++ b/stl-decomp-4j/src/main/java/com/github/servicenow/ds/stats/stl/StlFitStats.java
@@ -309,8 +309,8 @@ public class StlFitStats {
 	/**
 	 * Compute the residual log likelihood of the residual with the specified standard deviation.
 	 *
-	 * @param sigma
-	 * @return
+	 * @param sigma standard deviation
+	 * @return residual log-likelihood
 	 */
 	public double getResidualLogLikelihood(double sigma) {
 		double var = sigma * sigma;

--- a/stl-decomp-4j/stl-decomp-4j.iml
+++ b/stl-decomp-4j/stl-decomp-4j.iml
@@ -8,12 +8,10 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8 (1)" jdkType="JavaSDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.6.1" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-simple:1.6.1" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.6.1" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Hi Jim,

I could not locate any warning in the `StlDemoRestServer` and `StlPerfTest` example projects. I hope it's fine to remote the dependency on `slf4j-simple`. Please let me know if I need to declare it in any of the example projects.

Cheers,
Shayan